### PR TITLE
Re-allow External Subcommands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,23 @@ jobs:
       run: |
         cargo test --workspace --all-features --all-targets --no-fail-fast
 
+  smoke-test:
+    name: Run smoke tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [stable]
+    steps:
+    - name: Install the appropriate Rust toolchain
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup default ${{ matrix.rust }}
+    - uses: actions/checkout@v2
+    - name: Run smoke test scripts
+      run: |
+        find tests -iname '*.t.sh' -print0 | xargs -0 -L1 sh
+
   coverage:
     name: Measure test coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,9 @@ jobs:
         rustup toolchain install ${{ matrix.rust }}
         rustup default ${{ matrix.rust }}
     - uses: actions/checkout@v2
+    - name: Pre-build in release mode
+      run: |
+        cargo build --release
     - name: Run smoke test scripts
       run: |
         find tests -iname '*.t.sh' -print0 | xargs -0 -L1 sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 fn app<'a, 'b>() -> clap::App<'a, 'b> {
-	use clap::{App, Arg};
+	use clap::{App, AppSettings, Arg};
 
 	App::new(env!("CARGO_PKG_NAME"))
 		.about(env!("CARGO_PKG_DESCRIPTION"))
@@ -24,6 +24,7 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
 				.takes_value(true)
 				.help("limits the number of times command is executed"),
 		)
+		.setting(AppSettings::AllowExternalSubcommands)
 }
 
 fn command(arg_matches: &clap::ArgMatches) -> Option<Command> {

--- a/tests/smoke/commands/test.sh
+++ b/tests/smoke/commands/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ $(( (RANDOM % 10) )) -le 3 ];
+then
+	echo "$0: Success!"
+	exit 0
+else
+	echo "$0: Try again..."
+	exit 1
+fi

--- a/tests/smoke/no-arguments.t.sh
+++ b/tests/smoke/no-arguments.t.sh
@@ -5,7 +5,7 @@ cd "$dir"
 
 output=$(cargo run --quiet --release -- 2>&1)
 
-if [ "$output" == "Error: no command given" ];
+if echo "$output" | tail -n 1 | grep -q "Error: no command given";
 then
 	echo "$0: passed"
 	exit 0

--- a/tests/smoke/no-arguments.t.sh
+++ b/tests/smoke/no-arguments.t.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+dir="$(dirname "$0")/../.."
+cd "$dir"
+
+output=$(cargo run --quiet --release -- 2>&1)
+
+if [ "$output" == "Error: no command given" ];
+then
+	echo "$0: passed"
+	exit 0
+else
+	echo "$0: failed: output = $output"
+	exit 1
+fi
+

--- a/tests/smoke/test-no-options.t.sh
+++ b/tests/smoke/test-no-options.t.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+dir="$(dirname "$0")/../.."
+cd "$dir"
+
+output=$(cargo run --quiet --release -- "$dir/tests/smoke/commands/test.sh" 2>&1)
+
+echo "$0: Command completed, $(echo "$output" | wc -l) lines of output"
+
+if echo "$output" | tail -n 1 | grep -q ": Success";
+then
+	echo "$0: passed"
+	exit 0
+else
+	echo "$0: failed: output = $output"
+	exit 1
+fi
+


### PR DESCRIPTION
Apparently, I missed this when extracting the expression into this new function.  Lesson learned: actually testing things is good practice, but it's _essential_ when you don't have the comfort of a test suite keeping an eye on these sorts of things.

Fixes GH-130.

- [x] Add a test that would have caught this.